### PR TITLE
fix: typo in position/scale menu

### DIFF
--- a/src/lib/editor/PositionScalePanel.svelte
+++ b/src/lib/editor/PositionScalePanel.svelte
@@ -183,7 +183,7 @@
 								active={activeTab === 'margins'}
 								class="flex-1 rounded-r-2xl"
 							>
-								Marings
+								Margins
 							</Button>
 						{/snippet}
 					</Tabs.Trigger>


### PR DESCRIPTION
As mentioned in #11, there's a small typo which this pr will fix.